### PR TITLE
fixing steam id query #22

### DIFF
--- a/functions_global.php
+++ b/functions_global.php
@@ -502,7 +502,7 @@
 
     function formatMethod(int $method) {
         $methods = ["client_steamid", "client_name", "client_ip", "admin_name", "admin_steamid", "map", "length"];
-        return $methods[$method-1];
+        return $methods[$method-1] ?? $methods[0];
     }
 
     function GetRowInfo($id, $result2 = null) {

--- a/index.php
+++ b/index.php
@@ -17,9 +17,9 @@
 
     $sql = "SELECT * FROM `KbRestrict_CurrentBans`";
     $pageType = "all";
-	$currentTime = time();
+    $currentTime = time();
     if(isset($_GET['active'])) {
-		$currentTime = time();
+        $currentTime = time();
         $sql .= " WHERE `is_removed`=0 AND `is_expired`=0 AND (time_stamp_end = 0 OR time_stamp_end > $currentTime)";
         $pageType = "active";
     } else if(isset($_GET['expired'])) {
@@ -27,45 +27,49 @@
         $pageType = "expired";
     }
 
-    if(isset($_GET['s']) || isset($_GET['m'])) {
-        $input = $_GET['s'];
-
+    if(isset($_GET['m']) && (isset($_GET['s']) || isset($_GET['length']))) {
+        $input = isset($_GET['s']) ? trim($_GET['s']) : "";
+        $queryComplete = "";
         $method = formatMethod(intval($_GET['m']));
-        if($method == "client_steamid" || $method == "admin_steamid") {
-            $input = str_replace(" ", "", $input);
 
+        if($method == "client_steamid" || $method == "admin_steamid") {
             $steam = new Steam();
-            $result = $steam->verifyAndConvertSteamID($input);
+            $result = $steam->verifyAndConvertSteamID(str_replace(" ", "", $input));
 
             if ($result['success']) {
-                $input = $result['steamID2'];
+                $convertedSteamID = $result['steamID2'];
+                if(!empty($convertedSteamID)) {
+                    $input = $convertedSteamID;
+                }
             } else {
                 error_log("Error converting SteamID: " . $result['error']);
             }
-            $queryComplete = "LIKE '%" . $GLOBALS['DB']->real_escape_string($input) . "%'";
-        } else if($method == "length" && isset($_GET['length'])) {
-            $lengthArray = $_GET['length'];
-            $lengthOperatorVal = intval($lengthArray[0]); // like greater or less or shit like this
-            $lengthOperator = "=";
+        } else if ($method == "length" && isset($_GET['length'])) {
+                $lengthArray = $_GET['length'];
+                $lengthOperatorVal = intval($lengthArray[0]); // like greater or less or shit like this
+                $lengthOperator = "=";
 
-            if($lengthOperatorVal == 2) {$lengthOperator = ">";}
-            if($lengthOperatorVal == 3) {$lengthOperator = "<";}
-            if($lengthOperatorVal == 4) {$lengthOperator = ">=";}
-            if($lengthOperatorVal == 5) {$lengthOperator = "<=";}
+                if($lengthOperatorVal == 2) {$lengthOperator = ">";}
+                if($lengthOperatorVal == 3) {$lengthOperator = "<";}
+                if($lengthOperatorVal == 4) {$lengthOperator = ">=";}
+                if($lengthOperatorVal == 5) {$lengthOperator = "<=";}
 
-            $length;
-            if(isset($_GET['custom']) && $lengthArray[1] == -2) {
-                $length = intval($_GET['custom']); // in minutes
-            } else {
-                $length = $lengthArray[1];
-                if($length != -1) {
-                    $length = $length / 60; // we need to get length in minutes
+                $length;
+                if(isset($_GET['custom']) && $lengthArray[1] == -2) {
+                    $length = intval($_GET['custom']); // in minutes
+                } else {
+                    $length = $lengthArray[1];
+                    if($length != -1) {
+                        $length = $length / 60; // we need to get length in minutes
+                    }
                 }
+
+                $queryComplete = $lengthOperator . " " . $length;
             }
 
-            $queryComplete = $lengthOperator . " " . $length;
-        } else {
-            $queryComplete = "LIKE '%" . $GLOBALS['DB']->real_escape_string($input) . "%'";
+        if($queryComplete == "") {
+            $input = $GLOBALS['DB']->real_escape_string($input);
+            $queryComplete = "LIKE '%$input%'";
         }
 
         if(str_contains($sql, "WHERE")) {
@@ -89,7 +93,7 @@
     $pageActiveNum = 2;
     if($pageType == "all") {
         $pageActiveNum = 0;
-        $pageName = "KBan List";
+        $pageName = "Kban List";
         $icon = "<i class='fa-solid fa-house'></i>";
     } else if($pageType == "active") {
         $pageActiveNum = 1;
@@ -203,7 +207,7 @@
                                             $isExpired          = ($result1['is_expired'] == 1) ? true : false;
                                             $isRemoved          = ($result1['is_removed'] == 1) ? true : false; 
                                             $map                = $result1['map'];
-                                            
+
                                             $adminName = $admin->GetAdminNameFromSteamID($adminSteamID);
 
                                             $length = $kban->formatLength(($time_stamp_end - $time_stamp_start));
@@ -270,7 +274,7 @@
                                             echo "<td>$reason</td>";
                                             echo "<td>$adminName</td>";
                                             echo "<td class='row-length' id='length-$id'>$length</td>";
-                                        
+
                                             echo "</tr>";
 
                                             echo "<tr id='diva-$id-tr' style='display: none; width: 100%; height: 100%;'>";

--- a/index.php
+++ b/index.php
@@ -29,25 +29,20 @@
 
     if(isset($_GET['s']) || isset($_GET['m'])) {
         $input = $_GET['s'];
-        $queryComplete = "LIKE '%$input%'";
 
         $method = formatMethod(intval($_GET['m']));
         if($method == "client_steamid" || $method == "admin_steamid") {
-            if(!str_contains($input, "STEAMID")) {
-                if(str_contains($input, " ")) {
-                    $input = str_replace(" ", "", $input);
-                }
-            }
+            $input = str_replace(" ", "", $input);
 
             $steam = new Steam();
             $result = $steam->verifyAndConvertSteamID($input);
 
             if ($result['success']) {
-                $convertedSteamID = $result['steamID2'];
-                $input = $convertedSteamID;
+                $input = $result['steamID2'];
             } else {
                 error_log("Error converting SteamID: " . $result['error']);
             }
+            $queryComplete = "LIKE '%" . $GLOBALS['DB']->real_escape_string($input) . "%'";
         } else if($method == "length" && isset($_GET['length'])) {
             $lengthArray = $_GET['length'];
             $lengthOperatorVal = intval($lengthArray[0]); // like greater or less or shit like this
@@ -69,6 +64,8 @@
             }
 
             $queryComplete = $lengthOperator . " " . $length;
+        } else {
+            $queryComplete = "LIKE '%" . $GLOBALS['DB']->real_escape_string($input) . "%'";
         }
 
         if(str_contains($sql, "WHERE")) {

--- a/logs.php
+++ b/logs.php
@@ -49,7 +49,19 @@
     if(isset($_GET['s'])) {
         $input = $_GET['s'];
         $method = formatMethod(intval($_GET['m']));
-        $sql .= " WHERE `$method` LIKE '%$input%'";
+
+        if($method == "client_steamid" || $method == "admin_steamid") {
+            $input = str_replace(" ", "", $input);
+            $steam = new Steam();
+            $result = $steam->verifyAndConvertSteamID($input);
+            if ($result['success']) {
+                $input = $result['steamID2'];
+            } else {
+                error_log("Error converting SteamID: " . $result['error']);
+            }
+        }
+
+        $sql .= " WHERE `$method` LIKE '%" . $GLOBALS['DB']->real_escape_string($input) . "%'";
     }
 
     $sql_query = $GLOBALS['DB']->query($sql);

--- a/logs.php
+++ b/logs.php
@@ -46,22 +46,24 @@
     $sql = "SELECT * FROM ";
     $sql .= ($isWeb) ? "`KbRestrict_weblogs`" : "`KbRestrict_srvlogs`";
 
-    if(isset($_GET['s'])) {
-        $input = $_GET['s'];
+    if(isset($_GET['s']) && isset($_GET['m'])) {
+        $input = trim($_GET['s']);
         $method = formatMethod(intval($_GET['m']));
 
         if($method == "client_steamid" || $method == "admin_steamid") {
-            $input = str_replace(" ", "", $input);
+            $steamInput = str_replace(" ", "", $input);
             $steam = new Steam();
-            $result = $steam->verifyAndConvertSteamID($input);
-            if ($result['success']) {
+            $result = $steam->verifyAndConvertSteamID($steamInput);
+
+            if ($result['success'] && !empty($result['steamID2'])) {
                 $input = $result['steamID2'];
             } else {
                 error_log("Error converting SteamID: " . $result['error']);
             }
         }
 
-        $sql .= " WHERE `$method` LIKE '%" . $GLOBALS['DB']->real_escape_string($input) . "%'";
+        $input = $GLOBALS['DB']->real_escape_string($input);
+        $sql .= " WHERE `$method` LIKE '%$input%'";
     }
 
     $sql_query = $GLOBALS['DB']->query($sql);


### PR DESCRIPTION
In index.php, the old flow did this:

1. Took raw input and immediately built LIKE '%input%'
2. Then tried to convert SteamID formats
3. But the SQL was already using the old value, so conversion had no effect

That is why searching with Steam3 ([U:1:...]) or Steam64 (7656...) failed when DB rows were stored as Steam2 (STEAM_0:X:Y).

What was changed:

1. SteamID conversion now happens first for SteamID fields
2. SQL LIKE is built after conversion, using the converted Steam2 value
3. Input is escaped with real_escape_string before being appended to SQL
4. The same SteamID normalization logic was also added to logs.php, so logs search behaves the same way

Searching with Steam2, Steam3, or Steam64 now maps to the same account format before querying
<img width="1762" height="954" alt="image" src="https://github.com/user-attachments/assets/0ebba899-8073-46a1-9008-64ec577a6ede" />
