### PR TITLE
Security Hardening: Web SQL and Request Integrity

### DIFF
--- a/functions_global.php
+++ b/functions_global.php
@@ -153,12 +153,6 @@
                     `admin_name_removed`=?, `admin_steamid_removed`=?, `reason_removed`=?, 
                     `time_stamp_removed`=? WHERE `id`=?";
             $stmt = $GLOBALS['DB']->prepare($sql);
-            $stmt->bind_param("sssii", $adminName, $adminSteamID, $reason, $time_removed, $id);
-            $stmt->execute();
-            $stmt->close();
-
-
-            $stmt = $GLOBALS['DB']->prepare($sql);
             $stmt->bind_param("ssssi", $adminName, $adminSteamID, $reason, $time_removed, $id);
             $stmt->execute();
             $stmt->close();
@@ -298,24 +292,26 @@
         }
 
         public function getKbanInfoFromID($id) {
-            $sql = "SELECT * FROM `KbRestrict_CurrentBans` WHERE `id`='$id'";
-            $query = $GLOBALS['DB']->query($sql);
-
-            $results = $query->fetch_all(MYSQLI_ASSOC);
-            $query->free();
-
-            foreach($results as $result) {
-                return $result;
-            }
+            $stmt = $GLOBALS['DB']->prepare("SELECT * FROM `KbRestrict_CurrentBans` WHERE `id` = ?");
+            $stmt->bind_param("i", $id);
+            $stmt->execute();
+            $query = $stmt->get_result();
+            $result = $query->fetch_assoc();
+            $stmt->close();
+            return $result ?: null;
         }
 
         public function GetKbansNumber($steamID, $IP = "") {
             $search = (empty($steamID)) ? $IP : $steamID;
             $searchMethod = (empty($steamID)) ? "client_ip" : "client_steamid";
             
-            $queryA = $GLOBALS['DB']->query("SELECT * FROM `KbRestrict_CurrentBans` WHERE `$searchMethod`='$search'");
-            $rows = $queryA->num_rows;
-            $queryA->free();
+            $stmt = $GLOBALS['DB']->prepare("SELECT COUNT(*) AS total FROM `KbRestrict_CurrentBans` WHERE `$searchMethod` = ?");
+            $stmt->bind_param("s", $search);
+            $stmt->execute();
+            $queryA = $stmt->get_result();
+            $row = $queryA->fetch_assoc();
+            $stmt->close();
+            $rows = intval($row['total'] ?? 0);
             return $rows;
         }
         
@@ -323,9 +319,13 @@
             $search = (empty($steamID)) ? $IP : $steamID;
             $searchMethod = (empty($steamID)) ? "client_ip" : "client_steamid";
 
-            $queryA = $GLOBALS['DB']->query("SELECT * FROM `KbRestrict_CurrentBans` WHERE `$searchMethod`='$search' AND `is_removed`=0");
-            $rows = $queryA->num_rows;
-            $queryA->free();
+            $stmt = $GLOBALS['DB']->prepare("SELECT COUNT(*) AS total FROM `KbRestrict_CurrentBans` WHERE `$searchMethod` = ? AND `is_removed` = 0");
+            $stmt->bind_param("s", $search);
+            $stmt->execute();
+            $queryA = $stmt->get_result();
+            $row = $queryA->fetch_assoc();
+            $stmt->close();
+            $rows = intval($row['total'] ?? 0);
             return $rows;
         }
 
@@ -465,9 +465,12 @@
         }
 
         public function IsSteamIDAlreadyBanned($steamID) {
-            $query = $GLOBALS['DB']->query("SELECT * FROM `KbRestrict_CurrentBans` WHERE `client_steamid`='$steamID'");
+            $stmt = $GLOBALS['DB']->prepare("SELECT * FROM `KbRestrict_CurrentBans` WHERE `client_steamid` = ?");
+            $stmt->bind_param("s", $steamID);
+            $stmt->execute();
+            $query = $stmt->get_result();
             $results = $query->fetch_all(MYSQLI_ASSOC);
-            $query->free();
+            $stmt->close();
 
             foreach ($results as $result) {
                 $isActive = ($result['is_expired'] == 0 && $result['is_removed'] == 0);
@@ -498,6 +501,30 @@
         }
 
         return false;
+    }
+
+    function EnsureCsrfToken() {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if (empty($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+
+        return $_SESSION['csrf_token'];
+    }
+
+    function ValidateCsrfToken($token) {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if (empty($_SESSION['csrf_token']) || empty($token)) {
+            return false;
+        }
+
+        return hash_equals($_SESSION['csrf_token'], $token);
     }
 
     function formatMethod(int $method) {

--- a/functions_url.php
+++ b/functions_url.php
@@ -9,12 +9,17 @@
         return htmlspecialchars($sanitized, ENT_QUOTES, 'UTF-8'); // Escape HTML entities
     }
 
-    if (isset($_GET['id']) && !isset($_GET['reban']) && !isset($_GET['edit'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['id']) && !isset($_GET['reban']) && !isset($_GET['edit'])) {
         $id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
         showKbanInfo($id);
     }
 
-    if (isset($_GET['oldid']) && !isset($_GET['reban']) && !isset($_GET['edit'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['oldid']) && !isset($_POST['reban']) && !isset($_POST['edit'])) {
+        if (!ValidateCsrfToken(filter_input(INPUT_POST, 'csrf_token', FILTER_UNSAFE_RAW))) {
+            http_response_code(403);
+            die();
+        }
+
         if (!isset($_COOKIE['steamID'])) {
             die();
         }
@@ -22,7 +27,7 @@
         $admin = new Admin();
         $admin->UpdateAdminInfo($_COOKIE['steamID']);
 
-        $id = filter_input(INPUT_GET, 'oldid', FILTER_SANITIZE_NUMBER_INT);
+        $id = filter_input(INPUT_POST, 'oldid', FILTER_SANITIZE_NUMBER_INT);
         
         $kban = new Kban();
         $info = $kban->getKbanInfoFromID($id);
@@ -30,7 +35,7 @@
             die();
         }
         
-        $reason = sanitizeString(filter_input(INPUT_GET, 'reason', FILTER_SANITIZE_STRING));
+        $reason = sanitizeString(filter_input(INPUT_POST, 'reason', FILTER_UNSAFE_RAW));
         
         if (!$kban->UnbanByID($id, $reason)) {
             die();
@@ -43,15 +48,20 @@
         GetRowInfo($id);
     }
 
-    if (isset($_GET['add']) && isset($_GET['playerName'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add']) && isset($_POST['playerName'])) {
+        if (!ValidateCsrfToken(filter_input(INPUT_POST, 'csrf_token', FILTER_UNSAFE_RAW))) {
+            http_response_code(403);
+            die();
+        }
+
         if (!IsAdminLoggedIn()) {
             die();
         }
 
-        $playerName = sanitizeString(filter_input(INPUT_GET, 'playerName', FILTER_SANITIZE_STRING));
-        $playerSteamID = sanitizeString(filter_input(INPUT_GET, 'playerSteamID', FILTER_SANITIZE_STRING));
-        $length = filter_input(INPUT_GET, 'length', FILTER_SANITIZE_NUMBER_INT);
-        $reason = sanitizeString(filter_input(INPUT_GET, 'reason', FILTER_SANITIZE_STRING));
+        $playerName = sanitizeString(filter_input(INPUT_POST, 'playerName', FILTER_UNSAFE_RAW));
+        $playerSteamID = sanitizeString(filter_input(INPUT_POST, 'playerSteamID', FILTER_UNSAFE_RAW));
+        $length = filter_input(INPUT_POST, 'length', FILTER_SANITIZE_NUMBER_INT);
+        $reason = sanitizeString(filter_input(INPUT_POST, 'reason', FILTER_UNSAFE_RAW));
 
         $icon = "<i class='fa-solid fa-xmark'></i>&nbsp";
         if (empty($playerName)) {
@@ -93,16 +103,21 @@
         $kban->addNewKban($playerName, $playerSteamID, $length, $reason);
     }
 
-    if (isset($_GET['edit']) && isset($_GET['playerName'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit']) && isset($_POST['playerName'])) {
+        if (!ValidateCsrfToken(filter_input(INPUT_POST, 'csrf_token', FILTER_UNSAFE_RAW))) {
+            http_response_code(403);
+            die();
+        }
+
         if (!isset($_COOKIE['steamID'])) {
             die();
         }
 
-        $id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
-        $playerName = sanitizeString(filter_input(INPUT_GET, 'playerName', FILTER_SANITIZE_STRING));
-        $playerSteamID = sanitizeString(filter_input(INPUT_GET, 'playerSteamID', FILTER_SANITIZE_STRING));
-        $length = filter_input(INPUT_GET, 'length', FILTER_SANITIZE_NUMBER_INT);
-        $reason = sanitizeString(filter_input(INPUT_GET, 'reason', FILTER_SANITIZE_STRING));
+        $id = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $playerName = sanitizeString(filter_input(INPUT_POST, 'playerName', FILTER_UNSAFE_RAW));
+        $playerSteamID = sanitizeString(filter_input(INPUT_POST, 'playerSteamID', FILTER_UNSAFE_RAW));
+        $length = filter_input(INPUT_POST, 'length', FILTER_SANITIZE_NUMBER_INT);
+        $reason = sanitizeString(filter_input(INPUT_POST, 'reason', FILTER_UNSAFE_RAW));
 
         $icon = "<i class='fa-solid fa-xmark'></i>&nbsp";
         if (empty($playerName)) {
@@ -181,7 +196,12 @@
         $kban->EditKban($id, $playerName, $playerSteamID, $length, $reason);
     }
 
-    if (isset($_GET['delete'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
+        if (!ValidateCsrfToken(filter_input(INPUT_POST, 'csrf_token', FILTER_UNSAFE_RAW))) {
+            http_response_code(403);
+            die();
+        }
+
         if (!isset($_COOKIE['steamID'])) {
             die();
         }
@@ -192,7 +212,7 @@
             die();
         }
 
-        $id = filter_input(INPUT_GET, 'deleteid', FILTER_SANITIZE_NUMBER_INT);
+        $id = filter_input(INPUT_POST, 'deleteid', FILTER_SANITIZE_NUMBER_INT);
         $kban = new Kban();
         $kban->RemoveKbanFromDB($id);
         die();

--- a/header.php
+++ b/header.php
@@ -19,6 +19,8 @@
         setcookie("secret_key", "", 1, "/", $_SERVER['SERVER_NAME'], true, true);
         setcookie("aid", "", 1, "/", $_SERVER['SERVER_NAME'], true, true);
     }
+
+    $csrfToken = EnsureCsrfToken();
 ?>
 
 <head>
@@ -31,6 +33,8 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/4.2.0/mustache.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+    <meta name="csrf-token" content="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+    <script>window.CSRF_TOKEN = "<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>";</script>
     <script src="js/kbans.js"></script>
 </head>
 <body>

--- a/js/kbans.js
+++ b/js/kbans.js
@@ -12,6 +12,15 @@ function showKbanInfo(button) {
     }
 }
 
+function getCsrfToken() {
+    if (window.CSRF_TOKEN) {
+        return window.CSRF_TOKEN;
+    }
+
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : '';
+}
+
 function GoTop() {
     if (document.documentElement.scrollTop > 450 || document.body.scrollTop > 450) {
         document.body.scrollTop = 200;
@@ -42,8 +51,13 @@ function UnBanByID(id, reason) {
         }
     };
 
-    xmlResponse1.open("GET", "functions_url.php?oldid=" + encodeURIComponent(id) + '&reason=' + encodeURIComponent(reason), true);
-    xmlResponse1.send();
+    xmlResponse1.open("POST", "functions_url.php", true);
+    xmlResponse1.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xmlResponse1.send(
+        "oldid=" + encodeURIComponent(id) +
+        "&reason=" + encodeURIComponent(reason) +
+        "&csrf_token=" + encodeURIComponent(getCsrfToken())
+    );
 
     var xmlResponse2 = new XMLHttpRequest();
     xmlResponse2.onreadystatechange = function() {
@@ -79,9 +93,16 @@ function addNewKban(playerName, playerSteamID, length, reason) {
         }
     };
 
-    let url = "functions_url.php?add=1&playerName=" + encodeURIComponent(playerName) + '&playerSteamID=' + encodeURIComponent(playerSteamID) + '&length=' + encodeURIComponent(length) + '&reason=' + encodeURIComponent(reason);
-    xmlResponse.open("GET", url, true);
-    xmlResponse.send();
+    xmlResponse.open("POST", "functions_url.php", true);
+    xmlResponse.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xmlResponse.send(
+        "add=1" +
+        "&playerName=" + encodeURIComponent(playerName) +
+        "&playerSteamID=" + encodeURIComponent(playerSteamID) +
+        "&length=" + encodeURIComponent(length) +
+        "&reason=" + encodeURIComponent(reason) +
+        "&csrf_token=" + encodeURIComponent(getCsrfToken())
+    );
 }
 
 function EditKban(id, playerName, playerSteamID, length, reason) {
@@ -92,9 +113,17 @@ function EditKban(id, playerName, playerSteamID, length, reason) {
         }
     };
 
-    let url = "functions_url.php?edit=1&id=" + encodeURIComponent(id) + '&playerName=' + encodeURIComponent(playerName) + '&playerSteamID=' + encodeURIComponent(playerSteamID) + '&length=' + encodeURIComponent(length) + '&reason=' + encodeURIComponent(reason);
-    xmlResponse1.open("GET", url, true);
-    xmlResponse1.send();
+    xmlResponse1.open("POST", "functions_url.php", true);
+    xmlResponse1.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xmlResponse1.send(
+        "edit=1" +
+        "&id=" + encodeURIComponent(id) +
+        "&playerName=" + encodeURIComponent(playerName) +
+        "&playerSteamID=" + encodeURIComponent(playerSteamID) +
+        "&length=" + encodeURIComponent(length) +
+        "&reason=" + encodeURIComponent(reason) +
+        "&csrf_token=" + encodeURIComponent(getCsrfToken())
+    );
 }
 
 function RemoveKbanFromDBCheck(id) {
@@ -113,8 +142,13 @@ function RemoveKbanFromDB(id) {
         }
     };
 
-    xmlResponse1.open("GET", "functions_url.php?delete=1&deleteid=" + encodeURIComponent(id), true);
-    xmlResponse1.send();
+    xmlResponse1.open("POST", "functions_url.php", true);
+    xmlResponse1.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xmlResponse1.send(
+        "delete=1" +
+        "&deleteid=" + encodeURIComponent(id) +
+        "&csrf_token=" + encodeURIComponent(getCsrfToken())
+    );
 }
 
 function setActive(num) {


### PR DESCRIPTION
### Summary
This PR applies a targeted security hardening pass to the web panel without changing business behavior.

It focuses on:
1. Preventing CSRF on state-changing endpoints
2. Replacing remaining SQL string concatenation with prepared statements
3. Preserving existing UI/UX flows

---

### Changes

#### 1) Enforce `POST + CSRF` for write actions
Updated `functions_url.php` so mutating operations now require `POST` and a valid CSRF token:
- Unban (`oldid`)
- Add ban (`add`)
- Edit ban (`edit`)
- Delete ban (`delete`)

Read-only row info fetch (`id`) remains `GET` to avoid UI regression.

Files:
- functions_url.php

#### 2) Add CSRF token lifecycle
Added CSRF token helpers and token exposure to frontend:
- `EnsureCsrfToken()`
- `ValidateCsrfToken($token)`

Token is injected in page header as:
- `<meta name="csrf-token" ...>`
- `window.CSRF_TOKEN`

Files:
- functions_global.php
- header.php

#### 3) Switch frontend write calls from GET to POST
Updated AJAX calls to send `application/x-www-form-urlencoded` payloads with `csrf_token`:
- `UnBanByID`
- `addNewKban`
- `EditKban`
- `RemoveKbanFromDB`

Files:
- kbans.js

#### 4) Convert remaining dynamic SQL calls to prepared statements
Reworked remaining concatenated queries in `functions_global.php`:
- `getKbanInfoFromID`
- `GetKbansNumber`
- `GetRealKbansNumber`
- `IsSteamIDAlreadyBanned`

Also removed a duplicate/unreliable second `UPDATE` execution in `UnbanByID`.

Files:
- functions_global.php

---

### Security impact
- Reduces CSRF risk on all write operations in `functions_url.php`
- Removes remaining high-risk SQL concatenation patterns in core ban/query helpers
- Keeps search and display flows unchanged

---

### Compatibility
- No route/functionality removed
- Read-only `GET id` behavior preserved
- Existing write actions continue to work via updated JS calls

---

### Validation notes
- Static review completed on all modified paths

---

### Suggested manual QA
1. Add/Edit/Unban/Delete from UI still works for authorized admins
2. Direct `GET` calls to write actions no longer mutate state
3. Requests without valid CSRF token return `403`
4. Row info fetch via `GET id` still renders correctly